### PR TITLE
fix: adding missing awaits

### DIFF
--- a/lib/VWOClient.ts
+++ b/lib/VWOClient.ts
@@ -49,7 +49,7 @@ export interface IVWOClient {
     context: Record<string, any>,
     eventProperties: Record<string, dynamic>,
   ): Promise<Record<string, boolean>>;
-  setAttribute(attributeKey: string, attributeValue: boolean | string | number, context: Record<string, any>): void;
+  setAttribute(attributeKey: string, attributeValue: boolean | string | number, context: Record<string, any>): Promise<void>;
 }
 
 export class VWOClient implements IVWOClient {
@@ -247,7 +247,7 @@ export class VWOClient implements IVWOClient {
    * @param {string} attributeValue - The value of the attribute to set.
    * @param {ContextModel} context - The context in which the attribute should be set, must include a valid user ID.
    */
-  setAttribute(attributeKey: string, attributeValue: boolean | string | number, context: Record<string, any>): void {
+  async setAttribute(attributeKey: string, attributeValue: boolean | string | number, context: Record<string, any>): Promise<void> {
     const apiName = 'setAttribute';
 
     try {
@@ -294,7 +294,7 @@ export class VWOClient implements IVWOClient {
       const contextModel = new ContextModel().modelFromDictionary(context);
 
       // Proceed with setting the attribute if validation is successful
-      new SetAttributeApi().setAttribute(this.settings, attributeKey, attributeValue, contextModel);
+      await new SetAttributeApi().setAttribute(this.settings, attributeKey, attributeValue, contextModel);
     } catch (err) {
       // Log any errors encountered during the operation
       LogManager.Instance.info(

--- a/lib/api/GetFlag.ts
+++ b/lib/api/GetFlag.ts
@@ -209,7 +209,7 @@ export class FlagApi implements IGetFlag {
 
           _updateIntegrationsDecisionObject(passedRolloutCampaign, variation, passedRulesInformation, decision);
 
-          createAndSendImpressionForVariationShown(settings, passedRolloutCampaign.getId(), variation.getId(), context);
+          await createAndSendImpressionForVariationShown(settings, passedRolloutCampaign.getId(), variation.getId(), context);
         }
       }
     } else if (rollOutRules.length === 0) {
@@ -267,7 +267,7 @@ export class FlagApi implements IGetFlag {
 
           _updateIntegrationsDecisionObject(campaign, variation, passedRulesInformation, decision);
 
-          createAndSendImpressionForVariationShown(settings, campaign.getId(), variation.getId(), context);
+          await createAndSendImpressionForVariationShown(settings, campaign.getId(), variation.getId(), context);
         }
       }
     }
@@ -299,7 +299,7 @@ export class FlagApi implements IGetFlag {
         }),
       );
 
-      createAndSendImpressionForVariationShown(
+      await createAndSendImpressionForVariationShown(
         settings,
         feature.getImpactCampaign()?.getCampaignId(),
         isEnabled ? 2 : 1, // 2 is for Variation(flag enabled), 1 is for Control(flag disabled)

--- a/lib/api/SetAttribute.ts
+++ b/lib/api/SetAttribute.ts
@@ -26,7 +26,7 @@ interface ISetAttribute {
    * @param attributeValue The value of the attribute.
    * @param context Context containing user information.
    */
-  setAttribute(settings: SettingsModel, attributeKey: string, attributeValue: any, context: ContextModel): void;
+  setAttribute(settings: SettingsModel, attributeKey: string, attributeValue: any, context: ContextModel): Promise<void>;
 }
 
 export class SetAttributeApi implements ISetAttribute {
@@ -37,8 +37,8 @@ export class SetAttributeApi implements ISetAttribute {
    * @param attributeValue The value of the attribute.
    * @param context Context containing user information.
    */
-  setAttribute(settings: SettingsModel, attributeKey: string, attributeValue: any, context: ContextModel): void {
-    createImpressionForAttribute(settings, attributeKey, attributeValue, context);
+  async setAttribute(settings: SettingsModel, attributeKey: string, attributeValue: any, context: ContextModel): Promise<void> {
+    await createImpressionForAttribute(settings, attributeKey, attributeValue, context);
   }
 }
 
@@ -74,5 +74,5 @@ const createImpressionForAttribute = async (
   );
 
   // Send the constructed payload via POST request
-  sendPostApiRequest(properties, payload);
+  await sendPostApiRequest(properties, payload);
 };

--- a/lib/api/TrackEvent.ts
+++ b/lib/api/TrackEvent.ts
@@ -57,7 +57,7 @@ export class TrackApi implements ITrack {
   ): Promise<Record<string, boolean>> {
     if (doesEventBelongToAnyFeature(eventName, settings)) {
       // Create an impression for the track event
-      createImpressionForTrack(settings, eventName, context, eventProperties);
+      await createImpressionForTrack(settings, eventName, context, eventProperties);
       // Set and execute integration callback for the track event
       hooksService.set({ eventName: eventName, api: ApiEnum.TRACK });
       hooksService.execute(hooksService.get());
@@ -104,6 +104,7 @@ const createImpressionForTrack = async (
     context?.getUserAgent(),
     context?.getIpAddress(),
   );
+
   // Send the prepared payload via POST API request
-  sendPostApiRequest(properties, payload);
+  await sendPostApiRequest(properties, payload);
 };

--- a/lib/utils/ImpressionUtil.ts
+++ b/lib/utils/ImpressionUtil.ts
@@ -29,7 +29,7 @@ import { EventEnum } from '../enums/EventEnum';
  * @param {number} variationId - The ID of the variation shown to the user.
  * @param {ContextModel} context - The user context model containing user-specific data.
  */
-export const createAndSendImpressionForVariationShown = (
+export const createAndSendImpressionForVariationShown = async (
   settings: SettingsModel,
   campaignId: number,
   variationId: number,
@@ -55,5 +55,5 @@ export const createAndSendImpressionForVariationShown = (
   );
 
   // Send the constructed properties and payload as a POST request
-  sendPostApiRequest(properties, payload);
+  await sendPostApiRequest(properties, payload);
 };

--- a/lib/utils/NetworkUtil.ts
+++ b/lib/utils/NetworkUtil.ts
@@ -298,9 +298,8 @@ export function getAttributePayloadData(
  * Sends a POST API request with the specified properties and payload.
  * @param {any} properties - Properties for the request.
  * @param {any} payload - Payload for the request.
- * @returns {Promise<any>}
  */
-export function sendPostApiRequest(properties: any, payload: any) {
+export function sendPostApiRequest(properties: any, payload: any): Promise<ResponseModel | void> {
   NetworkManager.Instance.attachClient();
 
   const headers: Record<string, string> = {};

--- a/lib/utils/NetworkUtil.ts
+++ b/lib/utils/NetworkUtil.ts
@@ -298,6 +298,7 @@ export function getAttributePayloadData(
  * Sends a POST API request with the specified properties and payload.
  * @param {any} properties - Properties for the request.
  * @param {any} payload - Payload for the request.
+ * @returns {Promise<any>}
  */
 export function sendPostApiRequest(properties: any, payload: any) {
   NetworkManager.Instance.attachClient();
@@ -322,7 +323,7 @@ export function sendPostApiRequest(properties: any, payload: any) {
     SettingsService.Instance.port,
   );
 
-  NetworkManager.Instance.post(request).catch((err: ResponseModel) => {
+  return NetworkManager.Instance.post(request).catch((err: ResponseModel) => {
     LogManager.Instance.error(
       buildMessage(ErrorLogMessagesEnum.NETWORK_CALL_FAILED, {
         method: HttpMethodEnum.POST,

--- a/lib/utils/RuleEvaluationUtil.ts
+++ b/lib/utils/RuleEvaluationUtil.ts
@@ -70,7 +70,7 @@ export const evaluateRule = async (
     });
 
     // Send an impression for the variation shown
-    createAndSendImpressionForVariationShown(settings, campaign.getId(), whitelistedObject.variation.id, context);
+    await createAndSendImpressionForVariationShown(settings, campaign.getId(), whitelistedObject.variation.id, context);
   }
 
   // Return the results of the evaluation


### PR DESCRIPTION
We were experiencing issues with visitors not being registered in a test after calling `.getFlags(...)` from within our cloudfront proxy. But the visitor would register if we called the function from a local machine.

After reviewing the code, it appears some promises are not properly being awaited.

The `.getFlags(...)` function is async: https://github.com/wingify/vwo-fme-node-sdk/pull/5/files#diff-bdb598d5f15413f86f1e1a4f559db2f1dddfdd4ac05ba2146ce8ff3d8960eb05L51

And it calls `createAndSendImpressionForVariationShown(...)` multiple times.

While this function appears to not be a promise, it calls a promise (that is not returned) and from a blocking function. See here: `sendPostApiRequest` (https://github.com/wingify/vwo-fme-node-sdk/pull/5/files#diff-d55c90ee3fdb67379a734e67042ecbc7e1c0ae37b6891c7e9f3e2ba08bf63c61L302)

After changing that function to return the promise, it revealed several other places where an `await` should get applied.